### PR TITLE
Teacher access + Room

### DIFF
--- a/src/main/java/net/leloubil/pronotelib/entities/LessonData.java
+++ b/src/main/java/net/leloubil/pronotelib/entities/LessonData.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 })
 public class LessonData {
 
-    String teacher;
+    public String teacher;
 
     public String className;
 


### PR DESCRIPTION
The **teacher** variable was made **public**, it was *protected* for no apparent reason.

Another much more important problem, the room was deprecated, I don't know if it's due to the new versions of pronote, but in any case, at the json level, in part V, the first object was retrieved to retrieve the room whereas we have to take the object with a G value of 17.

exemple here : 

`      "ListeContenus": {
        "_T": 24,
        "V": [
          {
            "L": "HISTOIRE-GEOGRAPHIE",
            "N": "81F6F9C951ED6A",
            "G": 16
          },
          {
            "G": 3,
            "L": "RIVOAL M."
          },
          {
            "L": "109",
            "N": "136EF8E8D95B4D0",
            "G": 17
          }
        ]
      },`